### PR TITLE
Change proximity to a property

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Usage Example
     apds.enable_proximity_interrupt = True
 
     while True:
-            print(apds.proximity())
+            print(apds.proximity)
             apds.clear_interrupt()
 
 Hardware Set-up
@@ -153,7 +153,7 @@ To check for a object in proximity, see if a gesture is available first, then ge
 
   while True:
     if not interrupt_pin.value:
-      print(apds.proximity())
+      print(apds.proximity)
 
       # clear the interrupt
       apds.clear_interrupt()

--- a/adafruit_apds9960/apds9960.py
+++ b/adafruit_apds9960/apds9960.py
@@ -320,8 +320,9 @@ class APDS9960:
     def gesture_proximity_threshold(self, thresh):
         self._write8(APDS9960_GPENTH, thresh & 0xff)
 
+    @property
     def proximity(self):
-        """proximity value: range 0-255"""
+        """Proximity value: range 0-255"""
         return self._read8(APDS9960_PDATA)
 
     def clear_interrupt(self):

--- a/examples/apds9960_proximity_simpletest.py
+++ b/examples/apds9960_proximity_simpletest.py
@@ -14,7 +14,7 @@ apds.enable_proximity_interrupt = True
 while True:
     # print the proximity reading when the interrupt pin goes low
     if not int_pin.value:
-        print(apds.proximity())
+        print(apds.proximity)
 
         # clear the interrupt
         apds.clear_interrupt()

--- a/examples/apds9960_simpletest.py
+++ b/examples/apds9960_simpletest.py
@@ -1,0 +1,13 @@
+import time
+import board
+import busio
+from adafruit_apds9960.apds9960 import APDS9960
+
+i2c = busio.I2C(board.SCL, board.SDA)
+apds = APDS9960(i2c)
+
+apds.enable_proximity = True
+
+while True:
+    print(apds.proximity)
+    time.sleep(0.2)


### PR DESCRIPTION
**BREAKING CHANGE**

For #18 

Change proximity to a property. Examples and docs updated as needed. Also added new example `apds9960_simpletest.py` to comply with standard practice for example naming.

```python
Adafruit CircuitPython 5.0.0 on 2020-03-02; Adafruit CLUE nRF52840 Express with nRF52840
>>> import board
>>> from adafruit_apds9960.apds9960 import APDS9960
>>> apds = APDS9960(board.I2C())
>>> apds.enable_proximity
False
>>> apds.proximity
0
>>> apds.enable_proximity = True
>>> apds.proximity
32
>>> apds.proximity
84
>>>  
```