### PR TITLE
Remove unused interrupt pin arg and doc updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ Usage Example
 
     i2c = board.I2C()
     int_pin = digitalio.DigitalInOut(board.D5)
-    apds = APDS9960(i2c, interrupt_pin=int_pin)
+    apds = APDS9960(i2c)
 
     apds.enable_proximity = True
     apds.proximity_interrupt_threshold = (0, 175)
@@ -99,7 +99,7 @@ pin for proximity detection.
 
   int_pin = digitalio.DigitalInOut(board.A1)
   i2c = board.I2C()
-  apds = APDS9960(i2c, interrupt_pin=int_pin)
+  apds = APDS9960(i2c)
 
 Gestures
 --------

--- a/adafruit_apds9960/apds9960.py
+++ b/adafruit_apds9960/apds9960.py
@@ -36,7 +36,6 @@ Implementation Notes
 * Adafruit's Bus Device library: https://github.com/adafruit/Adafruit_CircuitPython_BusDevice
 """
 import time
-import digitalio
 from adafruit_register.i2c_bits import RWBits
 from adafruit_register.i2c_bit import RWBit
 from adafruit_bus_device.i2c_device import I2CDevice

--- a/adafruit_apds9960/apds9960.py
+++ b/adafruit_apds9960/apds9960.py
@@ -143,13 +143,7 @@ class APDS9960:
     _proximity_persistance = RWBits(4, APDS9960_PERS, 4)
 
     def __init__(
-        self,
-        i2c,
-        *,
-        address=0x39,
-        integration_time=0x01,
-        gain=0x01,
-        rotation=0
+        self, i2c, *, address=0x39, integration_time=0x01, gain=0x01, rotation=0
     ):
 
         self.buf129 = None

--- a/adafruit_apds9960/apds9960.py
+++ b/adafruit_apds9960/apds9960.py
@@ -19,7 +19,7 @@ Implementation Notes
 * Adafruit `APDS9960 Proximity, Light, RGB, and Gesture Sensor
   <https://www.adafruit.com/product/3595>`_ (Product ID: 3595)
 
-* Adafruit `Adafruit Feather nRF52840 Sense
+* Adafruit `Adafruit CLUE
   <https://www.adafruit.com/product/4500>`_ (Product ID: 4500)
 
 * Adafruit `Adafruit Feather nRF52840 Sense

--- a/adafruit_apds9960/apds9960.py
+++ b/adafruit_apds9960/apds9960.py
@@ -19,6 +19,15 @@ Implementation Notes
 * Adafruit `APDS9960 Proximity, Light, RGB, and Gesture Sensor
   <https://www.adafruit.com/product/3595>`_ (Product ID: 3595)
 
+* Adafruit `Adafruit Feather nRF52840 Sense
+  <https://www.adafruit.com/product/4500>`_ (Product ID: 4500)
+
+* Adafruit `Adafruit Feather nRF52840 Sense
+  <https://www.adafruit.com/product/4516>`_ (Product ID: 4516)
+
+* Adafruit `Adafruit Proximity Trinkey
+  <https://www.adafruit.com/product/5022>`_ (Product ID: 5022)
+
 **Software and Dependencies:**
 
 * Adafruit CircuitPython firmware for the supported boards:
@@ -97,7 +106,7 @@ class APDS9960:
     """
     APDS9900 provide basic driver services for the ASDS9960 breakout board
 
-    :param ~busio.I2C i2c: The I2C bus the BME280 is connected to
+    :param ~busio.I2C i2c: The I2C bus the ASDS9960 is connected to
     :param int address: The I2C device address. Defaults to :const:`0x39`
     :param int integration_time: integration time. Defaults to :const:`0x01`
     :param int gain: Device gain. Defaults to :const:`0x01`

--- a/adafruit_apds9960/apds9960.py
+++ b/adafruit_apds9960/apds9960.py
@@ -98,7 +98,6 @@ class APDS9960:
     APDS9900 provide basic driver services for the ASDS9960 breakout board
 
     :param ~busio.I2C i2c: The I2C bus the BME280 is connected to
-    :param ~microcontroller.Pin interrupt_pin: Interrupt pin. Defaults to `None`
     :param int address: The I2C device address. Defaults to :const:`0x39`
     :param int integration_time: integration time. Defaults to :const:`0x01`
     :param int gain: Device gain. Defaults to :const:`0x01`
@@ -139,7 +138,6 @@ class APDS9960:
         self,
         i2c,
         *,
-        interrupt_pin=None,
         address=0x39,
         integration_time=0x01,
         gain=0x01,
@@ -150,9 +148,6 @@ class APDS9960:
         self.buf2 = bytearray(2)
 
         self.i2c_device = I2CDevice(i2c, address)
-        self._interrupt_pin = interrupt_pin
-        if interrupt_pin:
-            self._interrupt_pin.switch_to_input(pull=digitalio.Pull.UP)
 
         if self._read8(APDS9960_ID) != 0xAB:
             raise RuntimeError()

--- a/examples/apds9960_proximity_simpletest.py
+++ b/examples/apds9960_proximity_simpletest.py
@@ -7,7 +7,7 @@ from adafruit_apds9960.apds9960 import APDS9960
 
 i2c = board.I2C()
 int_pin = digitalio.DigitalInOut(board.D5)
-apds = APDS9960(i2c, interrupt_pin=int_pin)
+apds = APDS9960(i2c)
 
 apds.enable_proximity = True
 apds.proximity_interrupt_threshold = (0, 175)


### PR DESCRIPTION
Addresses #33 with some minor doc updates for good measure.

These changes don't have any effect on the example code or the function of the library. The only thing that the incoming `interrupt_pin` arg used to do was to set an internal variable that was never actually used.

An alternative approach would be to update the doc to indicate that we want a `DigtalInOut` rather than a `Pin`. Given that it isn't used, I've started with this PR. Feel free to reject the PR if this approach isn't appropriate. :)