### PR TITLE
remove imp module usage

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,13 +22,6 @@ extensions = [
     "sphinx.ext.viewcode",
 ]
 
-# Mock out micropython ourselves so that we can make const a lambda.
-import imp
-
-m = imp.new_module("micropython")
-m.const = lambda x: x
-sys.modules["micropython"] = m
-
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "BusDevice": (


### PR DESCRIPTION
@ladyada 
Resolves: #47 

I'm not entirely sure what this section did originally, something with `micropython.const` clearly. All of the const usages that I found in this repo are on 'private' viariables that aren't listed in the documentation anyhow. 

I verified that I can successfully build the docs locally on python 3.12 now. The generated files look the same to me as the ones on the current live docs page.

I also checked the rest of the repos in the bundle and found 1 other similar instance to fix.